### PR TITLE
Subscribe to multiple topics using a single request

### DIFF
--- a/MQTT.py
+++ b/MQTT.py
@@ -391,10 +391,10 @@ class MQTTProtocol(Protocol):
         self.transport.write(str(header))
         self.transport.write(str(varHeader))
 
-    def subscribe(self, topic, requestedQoS=0, messageId=None):
+    def subscribe(self, topics, messageId=None):
         """
-        Only supports QoS = 0 subscribes
-        Only supports one subscription per message
+        Subscribe to the given topics. Topics is expected to be a list
+        of (topic, qos) tuples.
         """
         header = bytearray()
         varHeader = bytearray()
@@ -408,8 +408,9 @@ class MQTTProtocol(Protocol):
         else:
             varHeader.extend(self._encodeValue(messageId))
 
-        payload.extend(self._encodeString(topic))
-        payload.append(requestedQoS)
+        for topic, qos in topics:
+            payload.extend(self._encodeString(topic))
+            payload.append(qos)
 
         header.extend(self._encodeLength(len(varHeader) + len(payload)))
 


### PR DESCRIPTION
This patch allows subscribing to multiple topics using a single request. This was tested against Mosquitto implementations. The API changes, but is consistent with subscribeReceived().
