### PR TITLE
Unsubscribe from multiple topics, fix messageId variable name

### DIFF
--- a/MQTT.py
+++ b/MQTT.py
@@ -436,8 +436,11 @@ class MQTTProtocol(Protocol):
 
     def unsubscribe(self, topics, messageId=None):
         """
-        Unsubscribe from a list of topics.
+        Unsubscribe from one or more named topics.
         """
+        if isinstance(topics, basestring):
+            topics = [topics]
+
         header = bytearray()
         varHeader = bytearray()
         payload = bytearray()

--- a/MQTT.py
+++ b/MQTT.py
@@ -434,7 +434,10 @@ class MQTTProtocol(Protocol):
         self.transport.write(str(varHeader))
         self.transport.write(str(payload))
 
-    def unsubscribe(self, topic, messageId=None):
+    def unsubscribe(self, topics, messageId=None):
+        """
+        Unsubscribe from a list of topics.
+        """
         header = bytearray()
         varHeader = bytearray()
         payload = bytearray()
@@ -442,11 +445,12 @@ class MQTTProtocol(Protocol):
         header.append(0x0A << 4 | 0x01 << 1)
 
         if messageId is not None:
-            varHeader.extend(self._encodeValue(self.messageID))
+            varHeader.extend(self._encodeValue(messageId))
         else:
             varHeader.extend(self._encodeValue(random.randint(1, 0xFFFF)))
 
-        payload.extend(self._encodeString(topic))
+        for topic in topics:
+            payload.extend(self._encodeString(topic))
 
         header.extend(self._encodeLength(len(payload) + len(varHeader)))
 


### PR DESCRIPTION
Fix messageId variable name when sending unsubscribe requests. Allow sending multiple topics in a single request. This does change the API, but is pretty much in line with subscriptionReceived() and subackReceived().
